### PR TITLE
This applies changes to allow witnessing transactions that match cardano-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cardano-go
 
-This is a fork / re-brand of https://github.com/echovl/cardano-go , this fork is just to continue to develop this library as the upstream / original developer seems has lost insterest.
+Forking from https://github.com/safanaj/cardano-go to add functionality to allow loading transactions built externally into a TxBuilder.
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/safanaj/cardano-go)](https://pkg.go.dev/github.com/safanaj/cardano-go) ![ci](https://github.com/safanaj/cardano-go/workflows/test/badge.svg)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/melraidin/cardano-go)](https://pkg.go.dev/github.com/melraidin/cardano-go) ![ci](https://github.com/melraidin/cardano-go/workflows/test/badge.svg)
 
 cardano-go is a library for creating go applications that interact with the Cardano Blockchain. [WIP]
 
@@ -11,7 +11,7 @@ This project is mainly used by me to serve https://f2lb.bardels.me/
 ## Installation
 
 ```
-$ go get github.com/safanaj/cardano-go
+$ go get github.com/melraidin/cardano-go
 ```
 
 ## Usage
@@ -24,9 +24,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/blockfrost"
-	// "github.com/safanaj/cardano-go/koios"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/blockfrost"
+	// "github.com/melraidin/cardano-go/koios"
 )
 
 func main() {
@@ -50,8 +50,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 func main() {
@@ -98,7 +98,7 @@ func main() {
 package main
 
 import (
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 )
 
 func main() {
@@ -121,9 +121,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/blockfrost"
-	// "github.com/safanaj/cardano-go/koios"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/blockfrost"
+	// "github.com/melraidin/cardano-go/koios"
 )
 
 func main() {
@@ -144,7 +144,7 @@ func main() {
 ```go
 package main
 
-import "github.com/safanaj/cardano-go"
+import "github.com/melraidin/cardano-go"
 
 func main() {
 	txBuilder := cardano.NewTxBuilder(&cardano.ProtocolParams{})
@@ -165,8 +165,8 @@ func main() {
 package main
 
 import (
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 func main() {
@@ -192,8 +192,8 @@ func main() {
 package main
 
 import (
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 func main() {
@@ -225,8 +225,8 @@ package main
 import (
 	"math/big"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 func main() {
@@ -295,7 +295,7 @@ use_koios: false
 ### Installation
 
 ```
-$ git clone github.com/safanaj/cardano-go
+$ git clone github.com/melraidin/cardano-go
 $ make && sudo make install
 ```
 

--- a/address.go
+++ b/address.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/safanaj/cardano-go/internal/bech32"
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/internal/bech32"
+	"github.com/melraidin/cardano-go/internal/cbor"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/address_test.go
+++ b/address_test.go
@@ -3,8 +3,8 @@ package cardano
 import (
 	"testing"
 
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/internal/bech32"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/bech32"
 )
 
 const (

--- a/auxiliary_data.go
+++ b/auxiliary_data.go
@@ -3,7 +3,7 @@ package cardano
 import (
 	"reflect"
 
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 // Metadata represents the transaction metadata.

--- a/bech32/bech32.go
+++ b/bech32/bech32.go
@@ -3,8 +3,8 @@ package bech32
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go/bech32/prefixes"
-	"github.com/safanaj/cardano-go/internal/bech32"
+	"github.com/melraidin/cardano-go/bech32/prefixes"
+	"github.com/melraidin/cardano-go/internal/bech32"
 )
 
 type Bech32Prefix = prefixes.Bech32Prefix

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 
 	"github.com/blockfrost/blockfrost-go"
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 )
 
 // BlockfrostNode implements Node using the blockfrost API.

--- a/cardano-cli/cli.go
+++ b/cardano-cli/cli.go
@@ -14,7 +14,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 )
 
 var socketPath, fallbackSocketPath string

--- a/certificate.go
+++ b/certificate.go
@@ -3,7 +3,7 @@ package cardano
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 type CertificateType uint

--- a/cli/cpinger/main.go
+++ b/cli/cpinger/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/cardano-community/koios-go-client/v3"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/bech32"
-	koioscli "github.com/safanaj/cardano-go/koios"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/bech32"
+	koioscli "github.com/melraidin/cardano-go/koios"
 )
 
 var (

--- a/cli/csigner/cmd/sign.go
+++ b/cli/csigner/cmd/sign.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/cose"
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/libsodium"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/cose"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/libsodium"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/blake2b"
 )

--- a/cli/csigner/cmd/utils.go
+++ b/cli/csigner/cmd/utils.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/internal/cbor"
-	"github.com/safanaj/cardano-go/libsodium"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/libsodium"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/csigner/cmd/verify.go
+++ b/cli/csigner/cmd/verify.go
@@ -7,9 +7,9 @@ import (
 
 	coselib "github.com/veraison/go-cose"
 
-	"github.com/safanaj/cardano-go/cose"
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/libsodium"
+	"github.com/melraidin/cardano-go/cose"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/libsodium"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/blake2b"
 )

--- a/cli/csigner/main.go
+++ b/cli/csigner/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/safanaj/cardano-go/cli/csigner/cmd"
+	"github.com/melraidin/cardano-go/cli/csigner/cmd"
 )
 
 func main() {

--- a/cli/cwallet/cmd/node_utils.go
+++ b/cli/cwallet/cmd/node_utils.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"context"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/blockfrost"
-	"github.com/safanaj/cardano-go/koios"
-	"github.com/safanaj/cardano-go/wallet"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/blockfrost"
+	"github.com/melraidin/cardano-go/koios"
+	"github.com/melraidin/cardano-go/wallet"
 )
 
 func getNode(ctx context.Context, n cardano.Network, c Config) cardano.Node {

--- a/cli/cwallet/cmd/transfer.go
+++ b/cli/cwallet/cmd/transfer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cwallet/main.go
+++ b/cli/cwallet/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/safanaj/cardano-go/cli/cwallet/cmd"
+	"github.com/melraidin/cardano-go/cli/cwallet/cmd"
 )
 
 func main() {

--- a/cose/cip30.go
+++ b/cose/cip30.go
@@ -6,8 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/cbor"
 	"github.com/veraison/go-cose"
 )
 

--- a/credential.go
+++ b/credential.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 type StakeCredentialType uint64

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/pbkdf2"
 
-	"github.com/safanaj/cardano-go/internal/bech32"
+	"github.com/melraidin/cardano-go/internal/bech32"
 )
 
 // XPrvKey is the extended private key (64 bytes) appended with the chain code (32 bytes).

--- a/doc.go
+++ b/doc.go
@@ -5,9 +5,9 @@
 // The best way to get started working with cardano-go is to use `go get` to add the
 // library.
 //
-//  go get github.com/safanaj/cardano-go
-//	go get github.com/safanaj/cardano-go/node
-//	go get github.com/safanaj/cardano-go/tx
+//  go get github.com/melraidin/cardano-go
+//	go get github.com/melraidin/cardano-go/node
+//	go get github.com/melraidin/cardano-go/tx
 //
 // Hello cardano-go
 //
@@ -18,8 +18,8 @@
 //  import (
 //      "fmt"
 //
-//      "github.com/safanaj/cardano-go/node/blockfrost"
-//      "github.com/safanaj/cardano-go/types"
+//      "github.com/melraidin/cardano-go/node/blockfrost"
+//      "github.com/melraidin/cardano-go/types"
 //  )
 //
 //  func main() {

--- a/encoding.go
+++ b/encoding.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 var cborEnc, _ = cbor.CanonicalEncOptions().EncMode()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/safanaj/cardano-go
+module github.com/melraidin/cardano-go
 
 go 1.18
 

--- a/internal/cbor/example_test.go
+++ b/internal/cbor/example_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 func ExampleMarshal() {

--- a/koios/client.go
+++ b/koios/client.go
@@ -5,8 +5,8 @@ import (
 	"math/big"
 
 	"github.com/cardano-community/koios-go-client/v3"
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 const koiosTestnetHost = "testnet.koios.rest"

--- a/libsodium/libsodium.go
+++ b/libsodium/libsodium.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 
 	_ "github.com/otiai10/copy"
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/primitive.go
+++ b/primitive.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 type Network byte

--- a/primitive_test.go
+++ b/primitive_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 func TestAssetsEncoding(t *testing.T) {

--- a/script.go
+++ b/script.go
@@ -3,7 +3,7 @@ package cardano
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 type ScriptHashNamespace uint8

--- a/tx.go
+++ b/tx.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/cbor"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -80,6 +81,21 @@ type VKeyWitness struct {
 	_         struct{}      `cbor:",toarray"`
 	VKey      crypto.PubKey // ed25519 public key
 	Signature []byte        // ed25519 signature
+}
+
+// MarshalCBORWrapped wraps the VKeyWitness so that the CBOR structure matches what cardano-cli
+// generates when witnessing a transaction.
+func (vk *VKeyWitness) MarshalCBORWrapped() ([]byte, error) {
+	// It's not clear what the 0 represents in this structure but cardano-cli does it so we
+	// do too.
+	wrapper := struct {
+		_           struct{} `cbor:",toarray"`
+		CLIConstant int      `cbor:"0,keyasint"`
+		VK          VKeyWitness
+	}{
+		VK: *vk,
+	}
+	return cborEnc.Marshal(wrapper)
 }
 
 // TxInput is the transaction input.
@@ -279,6 +295,57 @@ type TxBody struct {
 	CollateralReturn      *TxOutput     `cbor:"16,keyasint,omitempty"`
 	TotalCollateral       Coin          `cbor:"17,keyasint,omitempty"`
 	ReferenceInputs       []*TxInput    `cbor:"18,keyasint,omitempty"`
+}
+
+// MarshalCBOR implements cbor.Marshaler for TxBody.
+// It applies CBOR tag 258 to the Inputs array to match cardano-cli output format.
+func (body *TxBody) MarshalCBOR() ([]byte, error) {
+	// Create a custom structure that will be marshaled with the tagged inputs
+	type taggedTxBody struct {
+		Inputs                cbor.Tag      `cbor:"0,keyasint"`
+		Outputs               []*TxOutput   `cbor:"1,keyasint"`
+		Fee                   Coin          `cbor:"2,keyasint"`
+		TTL                   Uint64        `cbor:"3,keyasint,omitempty"`
+		Certificates          []Certificate `cbor:"4,keyasint,omitempty"`
+		Withdrawals           interface{}   `cbor:"5,keyasint,omitempty"`
+		Update                interface{}   `cbor:"6,keyasint,omitempty"`
+		AuxiliaryDataHash     *Hash32       `cbor:"7,keyasint,omitempty"`
+		ValidityIntervalStart Uint64        `cbor:"8,keyasint,omitempty"`
+		Mint                  *Mint         `cbor:"9,keyasint,omitempty"`
+		ScriptDataHash        *Hash32       `cbor:"11,keyasint,omitempty"`
+		Collateral            []*TxInput    `cbor:"13,keyasint,omitempty"`
+		RequiredSigners       []AddrKeyHash `cbor:"14,keyasint,omitempty"`
+		NetworkID             Uint64        `cbor:"15,keyasint,omitempty"`
+		CollateralReturn      *TxOutput     `cbor:"16,keyasint,omitempty"`
+		TotalCollateral       Coin          `cbor:"17,keyasint,omitempty"`
+		ReferenceInputs       []*TxInput    `cbor:"18,keyasint,omitempty"`
+	}
+
+	// Create the tagged structure with tag 258 for Inputs
+	tagged := taggedTxBody{
+		Inputs: cbor.Tag{
+			Number:  258,
+			Content: body.Inputs,
+		},
+		Outputs:               body.Outputs,
+		Fee:                   body.Fee,
+		TTL:                   body.TTL,
+		Certificates:          body.Certificates,
+		Withdrawals:           body.Withdrawals,
+		Update:                body.Update,
+		AuxiliaryDataHash:     body.AuxiliaryDataHash,
+		ValidityIntervalStart: body.ValidityIntervalStart,
+		Mint:                  body.Mint,
+		ScriptDataHash:        body.ScriptDataHash,
+		Collateral:            body.Collateral,
+		RequiredSigners:       body.RequiredSigners,
+		NetworkID:             body.NetworkID,
+		CollateralReturn:      body.CollateralReturn,
+		TotalCollateral:       body.TotalCollateral,
+		ReferenceInputs:       body.ReferenceInputs,
+	}
+
+	return cborEnc.Marshal(tagged)
 }
 
 // Hash returns the transaction body hash using blake2b256.

--- a/tx.go
+++ b/tx.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -35,7 +35,7 @@ func NewTxBuilderFromTransaction(protocol *ProtocolParams, inputTx *Tx) *TxBuild
 	return &TxBuilder{
 		protocol: protocol,
 		pkeys:    []crypto.PrvKey{},
-		tx: inputTx,
+		tx:       inputTx,
 	}
 }
 
@@ -221,6 +221,16 @@ func (tb *TxBuilder) Reset() {
 	tb.changeReceiver = nil
 }
 
+// BuildWithoutValidation returns a new transaction without any
+// attempt to validate the transaction is balanced.
+func (tb *TxBuilder) BuildWithoutValidation() (*Tx, error) {
+	if err := tb.build(); err != nil {
+		return nil, err
+	}
+
+	return tb.tx, nil
+}
+
 // Build returns a new transaction using the inputs, outputs and keys provided.
 func (tb *TxBuilder) Build() (*Tx, error) {
 	inputAmount, outputAmount := tb.calculateAmounts()
@@ -256,11 +266,7 @@ func (tb *TxBuilder) Build() (*Tx, error) {
 		}
 	}
 
-	if err := tb.build(); err != nil {
-		return nil, err
-	}
-
-	return tb.tx, nil
+	return tb.BuildWithoutValidation()
 }
 
 func (tb *TxBuilder) addChangeIfNeeded(inputAmount, outputAmount *Value) error {

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -31,6 +31,14 @@ func NewTxBuilder(protocol *ProtocolParams) *TxBuilder {
 	}
 }
 
+func NewTxBuilderFromTransaction(protocol *ProtocolParams, inputTx *Tx) *TxBuilder {
+	return &TxBuilder{
+		protocol: protocol,
+		pkeys:    []crypto.PrvKey{},
+		tx: inputTx,
+	}
+}
+
 // AddInputs adds inputs to the transaction.
 func (tb *TxBuilder) AddInputs(inputs ...*TxInput) {
 	tb.tx.Body.Inputs = append(tb.tx.Body.Inputs, inputs...)
@@ -92,7 +100,9 @@ func (tb *TxBuilder) AddChangeIfNeeded(changeAddr Address) {
 func (tb *TxBuilder) calculateAmounts() (*Value, *Value) {
 	input, output := NewValue(0), NewValue(tb.totalDeposits())
 	for _, in := range tb.tx.Body.Inputs {
-		input = input.Add(in.Amount)
+		if in.Amount != nil {
+			input = input.Add(in.Amount)
+		}
 	}
 	for _, out := range tb.tx.Body.Outputs {
 		output = output.Add(out.Amount)
@@ -215,28 +225,34 @@ func (tb *TxBuilder) Reset() {
 func (tb *TxBuilder) Build() (*Tx, error) {
 	inputAmount, outputAmount := tb.calculateAmounts()
 
-	// Check input-output value conservation
-	if tb.changeReceiver == nil {
-		totalProduced := outputAmount.Add(NewValue(tb.tx.Body.Fee))
-		if inputOutputCmp := totalProduced.Cmp(inputAmount); inputOutputCmp == 1 || inputOutputCmp == 2 {
-			return nil, fmt.Errorf(
-				"insufficient input in transaction, got %v want %v",
-				inputAmount,
-				totalProduced,
-			)
-		} else if inputOutputCmp == -1 {
-			return nil, fmt.Errorf(
-				"fee too small, got %v want %v",
-				tb.tx.Body.Fee,
-				inputAmount.Sub(totalProduced),
-			)
+	// If we don't have an input amount (this is the case when
+	// we're using an imported transaction from cardano-wallet
+	// with NewTxBuilderFromTransaction()) we have to assume the
+	// transaction was already built properly.
+	if !inputAmount.IsZero() {
+		// Check input-output value conservation
+		if tb.changeReceiver == nil {
+			totalProduced := outputAmount.Add(NewValue(tb.tx.Body.Fee))
+			if inputOutputCmp := totalProduced.Cmp(inputAmount); inputOutputCmp == 1 || inputOutputCmp == 2 {
+				return nil, fmt.Errorf(
+					"insufficient input in transaction, got %v want %v",
+					inputAmount,
+					totalProduced,
+				)
+			} else if inputOutputCmp == -1 {
+				return nil, fmt.Errorf(
+					"fee too small, got %v want %v",
+					tb.tx.Body.Fee,
+					inputAmount.Sub(totalProduced),
+				)
+			}
 		}
-	}
 
-	if tb.changeReceiver != nil {
-		err := tb.addChangeIfNeeded(inputAmount, outputAmount)
-		if err != nil {
-			return nil, err
+		if tb.changeReceiver != nil {
+			err := tb.addChangeIfNeeded(inputAmount, outputAmount)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/tx_builder_test.go
+++ b/tx_builder_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/crypto"
 )
 
 var alonzoProtocol = &ProtocolParams{

--- a/tx_test.go
+++ b/tx_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/safanaj/cardano-go/crypto"
-	"github.com/safanaj/cardano-go/internal/cbor"
+	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/cbor"
 )
 
 func TestTxEncoding(t *testing.T) {

--- a/wallet/client.go
+++ b/wallet/client.go
@@ -3,7 +3,7 @@ package wallet
 import (
 	"fmt"
 
-	"github.com/safanaj/cardano-go"
+	"github.com/melraidin/cardano-go"
 	"github.com/tyler-smith/go-bip39"
 )
 

--- a/wallet/options.go
+++ b/wallet/options.go
@@ -1,8 +1,8 @@
 package wallet
 
 import (
-	"github.com/safanaj/cardano-go"
-	cardanocli "github.com/safanaj/cardano-go/cardano-cli"
+	"github.com/melraidin/cardano-go"
+	cardanocli "github.com/melraidin/cardano-go/cardano-cli"
 )
 
 type Options struct {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/crypto"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/crypto"
 	"github.com/tyler-smith/go-bip39"
 )
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -3,8 +3,8 @@ package wallet
 import (
 	"testing"
 
-	"github.com/safanaj/cardano-go"
-	"github.com/safanaj/cardano-go/internal/bech32"
+	"github.com/melraidin/cardano-go"
+	"github.com/melraidin/cardano-go/internal/bech32"
 	"github.com/tyler-smith/go-bip39"
 )
 


### PR DESCRIPTION
This change allows witnesses to be marshalled to CBOR in a manner that
matches cardano-cli. As well a fix is made to how transaction bodies
are marshalled to CBOR to make them match how cardano-cli does this so
that we can successfully witness a transaction and end up with the
same output. This required adding a tag to the transaction inputs
array.
